### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Installation
 
+[![API Testing](https://img.shields.io/badge/test%20this%20API%20on-RapidAPI.com-blue.svg)](https://rapidapi.com/package/LinkedIn/functions?utm_source=LinkedinGithub&utm_medium=button)
+
 ### Step 1: Download / clone the following plugins: 
 
  * **LinkedIn** to _Plugin/Linkedin_


### PR DESCRIPTION
I've added a link in your README to Linkedin's functions page in RapidAPI. I've done this for a few Linkedin SDKs to help those who are reading the READMEs, understand and test the API before use.